### PR TITLE
Change to full hyperlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".config/tmux"]
     path = .config/tmux
-    url = ../tmux.git
+    url = https://github.com/paddyroddy/tmux.git


### PR DESCRIPTION
Recent bug when cloning `yadm`

```sh
Init submodules
Submodule '.config/tmux' (git@github.com:paddyroddy/tmux.git) registered for path '.config/tmux'
fatal: could not get a repository handle for submodule '.config/tmux'
Error: bootstrap '/Users/paddy/.config/yadm/bootstrap.d/submodules' failed
```